### PR TITLE
Update mongodb-memory-server to 9.2.0

### DIFF
--- a/vitest-mongodb/package.json
+++ b/vitest-mongodb/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "mongodb-memory-server": "^8.12.0"
+    "mongodb-memory-server": "^9.2.0"
   }
 }


### PR DESCRIPTION
On Ubuntu 24.04 LTS using this package causes an error:
`Instance failed to start becausee a library is missing or cannot be opened: "libcrypto.so.1.1"`.

Updating the `mongodb-memory-server` to  `9.2.0` fixes the issue.